### PR TITLE
271119 analyse bpe poi osm rj

### DIFF
--- a/doc/271119_ANALYSE_BPE_POI_OSM_RJ.md
+++ b/doc/271119_ANALYSE_BPE_POI_OSM_RJ.md
@@ -125,11 +125,11 @@ Remarques :
 * la géométrie est homogène. Seul un point n'a pas de géométrie: *CNUMLPU 18121*
 
 * 10 point se superposent
-	*661	SECUR	5885	SECUR
-	*5439	ADMIN	6564	SCOL0
-	*5208	MEDSO	6572	MEDSO
-	*15248	CO103	15272	CO104
-	*22947	BVOIE	22948	BVOIE
+	* 661	SECUR	5885	SECUR
+	* 5439	ADMIN	6564	SCOL0
+	* 5208	MEDSO	6572	MEDSO
+	* 15248	CO103	15272	CO104
+	* 22947	BVOIE	22948	BVOIE
 
 * 197 éléments n'ont pas de *CDSFAMILLE* soit 2.06% du total des enregistrements.
 * 1 point n'a pas d'ORIGINE

--- a/doc/271119_ANALYSE_BPE_POI_OSM_RJ.md
+++ b/doc/271119_ANALYSE_BPE_POI_OSM_RJ.md
@@ -124,9 +124,8 @@ Remarques :
 * Un même CDSFAMILLE peut provenir de plusieurs ORIGINE
 * la géométrie est homogène. Seul un point n'a pas de géométrie: *CNUMLPU 18121*
 
-* 10 point se superposent
+* 10 points de la table se superposent(ci-dessous les CNUMLPU et les CDSFAMILLE de ces points)
 
-	* CNUMLPU	CDSFAMILLE	CNUMLPU		CDSFAMILL
 	* 661		SECUR		5885		SECUR
 	* 5439		ADMIN		6564		SCOL0
 	* 5208		MEDSO		6572		MEDSO

--- a/doc/271119_ANALYSE_BPE_POI_OSM_RJ.md
+++ b/doc/271119_ANALYSE_BPE_POI_OSM_RJ.md
@@ -125,11 +125,13 @@ Remarques :
 * la géométrie est homogène. Seul un point n'a pas de géométrie: *CNUMLPU 18121*
 
 * 10 point se superposent
-	* 661	SECUR	5885	SECUR
-	* 5439	ADMIN	6564	SCOL0
-	* 5208	MEDSO	6572	MEDSO
-	* 15248	CO103	15272	CO104
-	* 22947	BVOIE	22948	BVOIE
+
+	* CNUMLPU	CDSFAMILLE	CNUMLPU		CDSFAMILL
+	* 661		SECUR		5885		SECUR
+	* 5439		ADMIN		6564		SCOL0
+	* 5208		MEDSO		6572		MEDSO
+	* 15248		CO103		15272		CO104
+	* 22947		BVOIE		22948		BVOIE
 
 * 197 éléments n'ont pas de *CDSFAMILLE* soit 2.06% du total des enregistrements.
 * 1 point n'a pas d'ORIGINE

--- a/doc/271119_ANALYSE_BPE_POI_OSM_RJ.md
+++ b/doc/271119_ANALYSE_BPE_POI_OSM_RJ.md
@@ -123,7 +123,14 @@ Remarques :
 
 * Un même CDSFAMILLE peut provenir de plusieurs ORIGINE
 * la géométrie est homogène. Seul un point n'a pas de géométrie: *CNUMLPU 18121*
-* 10 point ont une géométrie exacte
+
+* 10 point se superposent
+	*661	SECUR	5885	SECUR
+	*5439	ADMIN	6564	SCOL0
+	*5208	MEDSO	6572	MEDSO
+	*15248	CO103	15272	CO104
+	*22947	BVOIE	22948	BVOIE
+
 * 197 éléments n'ont pas de *CDSFAMILLE* soit 2.06% du total des enregistrements.
 * 1 point n'a pas d'ORIGINE
 * 61 points ne sont pas renseigné (pas de CDSFAMILLE, ni ORIGINE, ni aucun libellé) * Pic de création des points en 1997 et 2007


### PR DESCRIPTION
Voici une version corrigée du fichier 271119 analyse bpe poi osm.
Plus de précisions ont été apportées sur la superposition des points de la table ILTALPU.