### PR TITLE
Création des objets nécessaires pour le recalage des objets topos

### DIFF
--- a/schema/plangestion/creation_ta_lig_topo_f_recal.sql
+++ b/schema/plangestion/creation_ta_lig_topo_f_recal.sql
@@ -1,0 +1,70 @@
+/*
+Création de la table TA_LIG_TOPO_F_RECAL devant permettre aux topos de recaler les objets du plans topographique fin quand c'est nécessaire.
+*/
+-- 1. Création de la table TA_LIG_TOPO_F_RECAL
+CREATE TABLE GEO.TA_LIG_TOPO_F_RECAL(
+    OBJECTID NUMBER(38,0),
+    CLA_INU NUMBER(38,0),
+    GEO_REF VARCHAR2(13 BYTE),
+    GEO_INSEE CHAR(3 BYTE),
+    GEOM SDO_GEOMETRY,
+    GEO_DV DATE,
+    GEO_DF DATE,
+    GEO_ON_VALIDE NUMBER(38,0),
+    GEO_TEXTE VARCHAR2(2048 BYTE),
+    GEO_LIG_OFFSET_D NUMBER(38,0),
+    GEO_LIG_OFFSET_G NUMBER(38,0),
+    GEO_TYPE CHAR(1 BYTE),
+    GEO_NMN VARCHAR2(20 BYTE),
+    GEO_DS DATE,
+    GEO_NMS VARCHAR2(20 BYTE),
+    GEO_DM DATE,
+    RECALAGE NUMBER(1,0)
+);
+
+-- 2. Création des commentaires de table
+COMMENT ON TABLE GEO.TA_LIG_TOPO_F_RECAL IS 'TABLE permettant le recalage des objets du plan topographique fin quand c''est nécessaire. Cette table dispose d''une table de log - TA_LIG_TOPO_F_RECAL_LOG - enregistrant toutes les modifications des données.';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL.OBJECTID IS 'Identifiant interne de l''objet geographique ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL.CLA_INU IS 'Reference a la classe a laquelle appartient l''objet ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL.GEO_REF IS 'Identifiant metier. Non obligatoire car certain objet geographique n''ont pas d''objet metier associe. Dans certains cas il peut contenir le numéro de dossier ta_gg_dossier d''origine du levé ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL.GEO_INSEE IS 'Code insee de la commune sur laquelle se situe l''objet ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL.GEOM IS 'Geometrie ORACLE de l''objet ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL.GEO_DV IS 'Date de debut de validite de l''objet ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL.GEO_DF IS 'Date de fin de validite de l''objet. ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL.GEO_ON_VALIDE IS 'Statut valide O/N de l''objet ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL.GEO_TEXTE IS 'Texte de commentaire ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL.GEO_LIG_OFFSET_D IS 'Decallage a droite par rapport a la generatrice ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL.GEO_LIG_OFFSET_G IS 'Decallage a gauche par rapport a la generatrice ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL.GEO_TYPE IS 'Type de geometrie de l''objet geographique ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL.GEO_NMN IS 'Auteur de la derniere modification ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL.GEO_DS IS 'Date de creation de l''objet ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL.GEO_NMS IS 'Auteur de la creation de l''objet ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL.GEO_DM IS 'Date de deniere modification de l''objet ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL.RECALAGE IS 'Champ permettant de distinguer les objets à recaler de ceux à ne pas toucher : 0 = objet à ne pas toucher ; 1 = objet à recaler';
+
+-- 3. Création de la clé primaire
+    ALTER TABLE GEO.TA_LIG_TOPO_F_RECAL 
+    ADD CONSTRAINT TA_LIG_TOPO_F_RECAL_PK 
+    PRIMARY KEY("OBJECTID") 
+    USING INDEX TABLESPACE "INDX_GEO";
+
+-- 4. Création des métadonnées spatiales
+    INSERT INTO USER_SDO_GEOM_METADATA(
+        TABLE_NAME, 
+        COLUMN_NAME, 
+        DIMINFO, 
+        SRID
+    )
+    VALUES(
+        'TA_LIG_TOPO_F_RECAL',
+        'geom',
+        SDO_DIM_ARRAY(SDO_DIM_ELEMENT('X', 594000, 964000, 0.005),SDO_DIM_ELEMENT('Y', 6987000, 7165000, 0.005)), 
+        2154
+    );
+    COMMIT;
+
+-- 5. Création de l'index spatial sur le champ geom
+    CREATE INDEX TA_LIG_TOPO_F_RECAL_SIDX
+    ON GEO.TA_LIG_TOPO_F_RECAL(GEOM)
+    INDEXTYPE IS MDSYS.SPATIAL_INDEX
+    PARAMETERS('layer_gtype=COLLECTION, tablespace=INDX_GEO, work_tablespace=DATA_TEMP');

--- a/schema/plangestion/creation_ta_lig_topo_f_recal_log.sql
+++ b/schema/plangestion/creation_ta_lig_topo_f_recal_log.sql
@@ -1,0 +1,74 @@
+/*
+Création de la table TA_LIG_TOPO_F_RECAL_LOG permettant de sauvegarder toutes les modifications et/ou suppressions des objets présents dans la table TA_LIG_TOPO_F_RECAL.
+*/
+-- 1. Création de la table TA_LIG_TOPO_F_RECAL_LOG
+CREATE TABLE GEO.TA_LIG_TOPO_F_RECAL_LOG(
+    OBJECTID NUMBER(38,0),
+    FID_IDENTIFIANT	NUMBER(38,0) NOT NULL,
+    CLA_INU NUMBER(38,0) NOT NULL,
+    GEO_REF VARCHAR2(13 BYTE),
+    GEO_INSEE CHAR(3 BYTE),
+    GEOM SDO_GEOMETRY,
+    GEO_DV DATE,
+    GEO_DF DATE,
+    GEO_ON_VALIDE NUMBER(38,0),
+    GEO_TEXTE VARCHAR2(2048 BYTE),
+    GEO_LIG_OFFSET_D NUMBER(38,0),
+    GEO_LIG_OFFSET_G NUMBER(38,0),
+    GEO_TYPE CHAR(1 BYTE),
+    GEO_NMN VARCHAR2(20 BYTE),
+    GEO_DS DATE,
+    GEO_NMS VARCHAR2(20 BYTE),
+    GEO_DM DATE,
+    RECALAGE NUMBER(1,0),
+    MODIFICATION NUMBER(38,0)
+);
+
+-- 2. Création des commentaires de table
+COMMENT ON TABLE GEO.TA_LIG_TOPO_F_RECAL_LOG IS 'Table de versionnement de la table TA_LIG_TOPO_F_RECAL. Elle contient toutes les mises à jour (à partir du 08.03.2021) et les suppressions de la table de recalage.';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL_LOG.OBJECTID IS 'Identifiant interne de l''objet geographique ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL_LOG.FID_IDENTIFIANT IS 'Identifiant de l''objet qui est/était présent dans la table de recalage.';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL_LOG.CLA_INU IS 'Reference a la classe a laquelle appartient l''objet ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL_LOG.GEO_REF IS 'Identifiant metier. Non obligatoire car certain objet geographique n''ont pas d''objet metier associe. Dans certains cas il peut contenir le numéro de dossier ta_gg_dossier d''origine du levé ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL_LOG.GEO_INSEE IS 'Code insee de la commune sur laquelle se situe l''objet ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL_LOG.GEOM IS 'Geometrie ORACLE de l''objet ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL_LOG.GEO_DV IS 'Date de debut de validite de l''objet ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL_LOG.GEO_DF IS 'Date de fin de validite de l''objet. ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL_LOG.GEO_ON_VALIDE IS 'Statut valide O/N de l''objet ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL_LOG.GEO_TEXTE IS 'Texte de commentaire ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL_LOG.GEO_LIG_OFFSET_D IS 'Decallage a droite par rapport a la generatrice ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL_LOG.GEO_LIG_OFFSET_G IS 'Decallage a gauche par rapport a la generatrice ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL_LOG.GEO_TYPE IS 'Type de geometrie de l''objet geographique ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL_LOG.GEO_NMN IS 'Auteur de la derniere modification ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL_LOG.GEO_DS IS 'Date de creation de l''objet ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL_LOG.GEO_NMS IS 'Auteur de la creation de l''objet ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL_LOG.GEO_DM IS 'Date de deniere modification de l''objet ';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL_LOG.RECALAGE IS 'Champ permettant de distinguer les objets à recaler de ceux à ne pas toucher : 0 = objet à ne pas toucher ; 1 = objet à recaler';
+COMMENT ON COLUMN GEO.TA_LIG_TOPO_F_RECAL_LOG.MODIFICATION IS 'Type de modification effectuée sur la donnée : 1 = mise à jour, 0 = suppression';
+
+-- 3. Création de la clé primaire
+    ALTER TABLE GEO.TA_LIG_TOPO_F_RECAL_LOG 
+    ADD CONSTRAINT TA_LIG_TOPO_F_RECAL_LOG_PK 
+    PRIMARY KEY("OBJECTID") 
+    USING INDEX TABLESPACE "INDX_GEO";
+
+-- 4. Création des métadonnées spatiales
+    INSERT INTO USER_SDO_GEOM_METADATA(
+        TABLE_NAME, 
+        COLUMN_NAME, 
+        DIMINFO, 
+        SRID
+    )
+    VALUES(
+        'TA_LIG_TOPO_F_RECAL_LOG',
+        'geom',
+        SDO_DIM_ARRAY(SDO_DIM_ELEMENT('X', 594000, 964000, 0.005),SDO_DIM_ELEMENT('Y', 6987000, 7165000, 0.005)), 
+        2154
+    );
+    COMMIT;
+
+-- 5. Création de l'index spatial sur le champ geom
+    CREATE INDEX TA_LIG_TOPO_F_RECAL_LOG_SIDX
+    ON GEO.TA_LIG_TOPO_F_RECAL_LOG(GEOM)
+    INDEXTYPE IS MDSYS.SPATIAL_INDEX
+    PARAMETERS('layer_gtype=COLLECTION, tablespace=INDX_GEO, work_tablespace=DATA_TEMP');

--- a/schema/plangestion/creation_ta_point_topo_f_recal.sql
+++ b/schema/plangestion/creation_ta_point_topo_f_recal.sql
@@ -1,0 +1,74 @@
+/*
+Création de la table TA_POINT_TOPO_F_RECAL devant permettre aux topos de recaler les objets du plans topographique fin quand c'est nécessaire.
+*/
+-- 1. Création de la table TA_POINT_TOPO_F_RECAL
+CREATE TABLE GEO.TA_POINT_TOPO_F_RECAL(
+    OBJECTID NUMBER(38,0),
+    CLA_INU NUMBER(38,0),
+    GEO_REF VARCHAR2(13 BYTE),
+    GEO_INSEE CHAR(3 BYTE),
+    GEOM SDO_GEOMETRY,
+    GEO_DV DATE,
+    GEO_DF DATE,
+    GEO_ON_VALIDE NUMBER(38,0),
+    GEO_TEXTE VARCHAR2(2048 BYTE),
+    GEO_POI_LN NUMBER(38,0),
+    GEO_POI_LA NUMBER(38,0),
+    GEO_POI_AG_ORIENTATION NUMBER(5,2),
+    GEO_POI_HA NUMBER(8,0),
+    GEO_POI_AG_INCLINAISON NUMBER(5,2),
+    GEO_TYPE CHAR(1 BYTE),
+    GEO_NMN VARCHAR2(20 BYTE),
+    GEO_DS DATE,
+    GEO_NMS VARCHAR2(20 BYTE),
+    GEO_DM DATE,
+    RECALAGE NUMBER(1,0)
+);
+
+-- 2. Création des commentaires de table
+COMMENT ON TABLE GEO.TA_POINT_TOPO_F_RECAL IS 'TABLE permettant le recalage des objets du plan topographique fin quand c''est nécessaire. Cette table dispose d''une table de log - TA_POINT_TOPO_F_RECAL_LOG - enregistrant toutes les modifications des données.';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL.OBJECTID IS 'Identifiant interne de l''objet geographique ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL.CLA_INU IS 'Reference a la classe a laquelle appartient l''objet ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL.GEO_REF IS 'Identifiant metier. Non obligatoire car certain objet geographique n''ont pas d''objet metier associe. Dans certains cas il peut contenir le numéro de dossier ta_gg_dossier d''origine du levé ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL.GEO_INSEE IS 'Code insee de la commune sur laquelle se situe l''objet ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL.GEOM IS 'Geometrie ORACLE de l''objet ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL.GEO_DV IS 'Date de debut de validite de l''objet ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL.GEO_DF IS 'Date de fin de validite de l''objet. ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL.GEO_ON_VALIDE IS 'Statut valide O/N de l''objet ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL.GEO_TEXTE IS 'Texte de commentaire ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL.GEO_POI_LN IS 'Longueur de l''objet (en cm) ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL.GEO_POI_LA IS 'Largeur de l''objet (en cm) ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL.GEO_POI_AG_ORIENTATION IS 'Orientation de l''objet (en degre) ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL.GEO_POI_HA IS 'Hauteur de l''objet (en cm) ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL.GEO_POI_AG_INCLINAISON IS 'Inclinaison de l''objet (en degre, par rapport a la verticale). ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL.GEO_TYPE IS 'Type de geometrie de l''objet geographique ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL.GEO_NMN IS 'Auteur de la derniere modification ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL.GEO_DS IS 'Date de creation de l''objet ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL.GEO_NMS IS 'Auteur de la creation de l''objet ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL.GEO_DM IS 'Date de derniere modification de l''objet ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL.RECALAGE IS 'Champ permettant de distinguer les objets à recaler de ceux à ne pas toucher : 0 = objet à ne pas toucher ; 1 = objet à recaler';
+
+-- 4. Création de la clé primaire
+    ALTER TABLE GEO.TA_POINT_TOPO_F_RECAL 
+    ADD CONSTRAINT TA_POINT_TOPO_F_RECAL_PK 
+    PRIMARY KEY("OBJECTID") 
+    USING INDEX TABLESPACE "INDX_GEO";
+
+-- 5. Création des métadonnées spatiales
+    INSERT INTO USER_SDO_GEOM_METADATA(
+        TABLE_NAME, 
+        COLUMN_NAME, 
+        DIMINFO, 
+        SRID
+    )
+    VALUES(
+        'TA_POINT_TOPO_F_RECAL',
+        'geom',
+        SDO_DIM_ARRAY(SDO_DIM_ELEMENT('X', 594000, 964000, 0.005),SDO_DIM_ELEMENT('Y', 6987000, 7165000, 0.005)), 
+        2154
+    );
+    COMMIT;
+
+-- 6. Création de l'index spatial sur le champ geom
+    CREATE INDEX "GEO"."TA_POINT_TOPO_F_RECAL_SIDX" ON "GEO"."TA_POINT_TOPO_F_RECAL" ("GEOM") 
+   INDEXTYPE IS "MDSYS"."SPATIAL_INDEX"  PARAMETERS (' LAYER_GTYPE = MULTIPOINT WORK_TABLESPACE=DATA_TEMP TABLESPACE=INDX_GEO');

--- a/schema/plangestion/creation_ta_point_topo_f_recal_log.sql
+++ b/schema/plangestion/creation_ta_point_topo_f_recal_log.sql
@@ -1,0 +1,80 @@
+/*
+Création de la table TA_POINT_TOPO_F_RECAL_LOG permettant le versionnement de la table TA_POINT_TOPO_F_RECAL. Elle contient toutes les mises à jour (à partir du 08.03.2021) et les suppressions de la table de recalage.
+*/
+-- 1. Création de la table TA_POINT_TOPO_F_RECAL_LOG
+CREATE TABLE GEO.TA_POINT_TOPO_F_RECAL_LOG(
+    OBJECTID NUMBER(38,0),
+    FID_IDENTIFIANT	NUMBER(38,0) NOT NULL,
+    CLA_INU NUMBER(38,0) NOT NULL,
+    GEO_REF VARCHAR2(13 BYTE),
+    GEO_INSEE CHAR(3 BYTE),
+    GEOM SDO_GEOMETRY,
+    GEO_DV DATE,
+    GEO_DF DATE,
+    GEO_ON_VALIDE NUMBER(38,0),
+    GEO_TEXTE VARCHAR2(2048 BYTE),
+    GEO_POI_LN NUMBER(38,0),
+    GEO_POI_LA NUMBER(38,0),
+    GEO_POI_AG_ORIENTATION NUMBER(5,2),
+    GEO_POI_HA NUMBER(8,0),
+    GEO_POI_AG_INCLINAISON NUMBER(5,2),
+    GEO_TYPE CHAR(1 BYTE),
+    GEO_NMN VARCHAR2(20 BYTE),
+    GEO_DS DATE,
+    GEO_NMS VARCHAR2(20 BYTE),
+    GEO_DM DATE,
+    RECALAGE NUMBER(1,0),
+    MODIFICATION NUMBER(38,0)
+);
+
+-- 2. Création des commentaires de table
+COMMENT ON TABLE GEO.TA_POINT_TOPO_F_RECAL_LOG IS 'Table de versionnement de la table TA_POINT_TOPO_F_RECAL. Elle contient toutes les mises à jour (à partir du 08.03.2021) et les suppressions de la table de recalage.';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL_LOG.OBJECTID IS 'Identifiant interne de l''objet geographique ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL_LOG.FID_IDENTIFIANT IS 'Identifiant de l''objet qui est/était présent dans la table de recalage.';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL_LOG.CLA_INU IS 'Reference a la classe a laquelle appartient l''objet ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL_LOG.GEO_REF IS 'Identifiant metier. Non obligatoire car certain objet geographique n''ont pas d''objet metier associe. Dans certains cas il peut contenir le numéro de dossier ta_gg_dossier d''origine du levé ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL_LOG.GEO_INSEE IS 'Code insee de la commune sur laquelle se situe l''objet ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL_LOG.GEOM IS 'Geometrie ORACLE de l''objet ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL_LOG.GEO_DV IS 'Date de debut de validite de l''objet ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL_LOG.GEO_DF IS 'Date de fin de validite de l''objet. ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL_LOG.GEO_ON_VALIDE IS 'Statut valide O/N de l''objet ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL_LOG.GEO_TEXTE IS 'Texte de commentaire ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL_LOG.GEO_POI_LN IS 'Longueur de l''objet (en cm) ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL_LOG.GEO_POI_LA IS 'Largeur de l''objet (en cm) ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL_LOG.GEO_POI_AG_ORIENTATION IS 'Orientation de l''objet (en degre) ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL_LOG.GEO_POI_HA IS 'Hauteur de l''objet (en cm) ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL_LOG.GEO_POI_AG_INCLINAISON IS 'Inclinaison de l''objet (en degre, par rapport a la verticale). ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL_LOG.GEO_TYPE IS 'Type de geometrie de l''objet geographique ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL_LOG.GEO_NMN IS 'Auteur de la derniere modification ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL_LOG.GEO_DS IS 'Date de creation de l''objet ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL_LOG.GEO_NMS IS 'Auteur de la creation de l''objet ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL_LOG.GEO_DM IS 'Date de derniere modification de l''objet ';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL_LOG.RECALAGE IS 'Champ permettant de distinguer les objets à recaler de ceux à ne pas toucher : 0 = objet à ne pas toucher ; 1 = objet à recaler';
+COMMENT ON COLUMN GEO.TA_POINT_TOPO_F_RECAL_LOG.MODIFICATION IS 'Type de modification effectuée sur la donnée : 1 = mise à jour, 0 = suppression';
+
+-- 4. Création de la clé primaire
+    ALTER TABLE GEO.TA_POINT_TOPO_F_RECAL_LOG 
+    ADD CONSTRAINT TA_POINT_TOPO_F_RECAL_LOG_PK 
+    PRIMARY KEY("OBJECTID") 
+    USING INDEX TABLESPACE "INDX_GEO";
+
+-- 5. Création des métadonnées spatiales
+    INSERT INTO USER_SDO_GEOM_METADATA(
+        TABLE_NAME, 
+        COLUMN_NAME, 
+        DIMINFO, 
+        SRID
+    )
+    VALUES(
+        'TA_POINT_TOPO_F_RECAL_LOG',
+        'geom',
+        SDO_DIM_ARRAY(SDO_DIM_ELEMENT('X', 594000, 964000, 0.005),SDO_DIM_ELEMENT('Y', 6987000, 7165000, 0.005)), 
+        2154
+    );
+    COMMIT;
+
+-- 6. Création de l'index spatial sur le champ geom
+    CREATE INDEX TA_POINT_TOPO_F_RECAL_LOG_SIDX
+    ON GEO.TA_POINT_TOPO_F_RECAL_LOG(GEOM)
+    INDEXTYPE IS MDSYS.SPATIAL_INDEX
+    PARAMETERS('layer_gtype=MULTIPOINT, tablespace=INDX_GEO, work_tablespace=DATA_TEMP');

--- a/schema/plangestion/creation_trigger_b_udx_ta_lig_topo_f_recal.sql
+++ b/schema/plangestion/creation_trigger_b_udx_ta_lig_topo_f_recal.sql
@@ -1,0 +1,53 @@
+-- Création du trigger B_UDX_TA_LIG_TOPO_F_RECAL_LOG
+/*
+Objectif : versionner toutes les modifications/suppressions de TA_LIG_TOPO_F_RECAL afin de pouvroi revenir à un état antérieur.
+*/
+
+create or replace TRIGGER B_UDX_TA_LIG_TOPO_F_RECAL
+    BEFORE UPDATE OR DELETE ON TA_LIG_TOPO_F_RECAL
+    FOR EACH ROW
+DECLARE
+    username varchar(30);
+    BEGIN
+        SELECT sys_context('USERENV','OS_USER') into username from dual;  
+        IF UPDATING THEN
+             INSERT INTO GEO.TA_LIG_TOPO_F_RECAL_LOG(FID_IDENTIFIANT, CLA_INU, GEO_REF, GEO_INSEE, GEOM, GEO_DV, GEO_DF, GEO_TEXTE, GEO_LIG_OFFSET_D, GEO_LIG_OFFSET_G, GEO_TYPE, GEO_NMN, GEO_DM, MODIFICATION) 
+            VALUES( :old.objectid,
+                :old.cla_inu,
+                :old.geo_ref,
+                :old.geo_insee,
+                :old.geom,
+                :old.geo_dv,
+                :old.geo_df,
+                :old.geo_texte,
+                :old.geo_lig_offset_d,
+                :old.geo_lig_offset_g,
+                :old.geo_type,
+                username,
+                sysdate,
+                1
+            );
+        END IF;
+        IF DELETING THEN
+            INSERT INTO GEO.TA_LIG_TOPO_F_RECAL_LOG(FID_IDENTIFIANT, CLA_INU, GEO_REF, GEO_INSEE, GEOM, GEO_DV, GEO_DF, GEO_TEXTE, GEO_LIG_OFFSET_D, GEO_LIG_OFFSET_G, GEO_TYPE, GEO_NMN, GEO_DM, MODIFICATION) 
+            VALUES( :old.objectid,
+                :old.cla_inu,
+                :old.geo_ref,
+                :old.geo_insee,
+                :old.geom,
+                :old.geo_dv,
+                :old.geo_df,
+                :old.geo_texte,
+                :old.geo_lig_offset_d,
+                :old.geo_lig_offset_g,
+                :old.geo_type,
+                username,
+                sysdate,
+                0
+            );
+        END IF;
+
+        EXCEPTION
+            WHEN OTHERS THEN
+                mail.sendmail('geotrigger@lillemetropole.fr',username || ' a provoque l''erreur : ' || SQLERRM,'ERREUR TRIGGER - geo/dev.TA_LIG_TOPO_F_RECAL_LOG','bjacq@lillemetropole.fr');
+    END;

--- a/schema/plangestion/creation_trigger_b_udx_ta_point_topo_f_recal.sql
+++ b/schema/plangestion/creation_trigger_b_udx_ta_point_topo_f_recal.sql
@@ -1,0 +1,59 @@
+-- Création du trigger B_UDX_TA_PT_TOPO_F_RECAL_LOG
+/*
+Objectif : versionner toutes les modifications/suppressions de TA_POINT_TOPO_F_RECAL afin de pouvroi revenir à un état antérieur.
+*/
+
+create or replace TRIGGER B_UDX_TA_POINT_TOPO_F_RECAL
+    BEFORE UPDATE OR DELETE ON TA_POINT_TOPO_F_RECAL
+    FOR EACH ROW
+DECLARE
+    username varchar(30);
+    BEGIN
+        SELECT sys_context('USERENV','OS_USER') into username from dual;  
+        IF UPDATING THEN
+             INSERT INTO GEO.TA_POINT_TOPO_F_RECAL_LOG(FID_IDENTIFIANT, CLA_INU, GEO_REF, GEO_INSEE, GEOM, GEO_DV, GEO_DF, GEO_TEXTE, GEO_POI_LN, GEO_POI_LA, GEO_POI_AG_ORIENTATION, GEO_POI_HA, GEO_POI_AG_INCLINAISON, GEO_TYPE, GEO_NMN, GEO_DM, MODIFICATION) 
+            VALUES( :old.objectid,
+                :old.cla_inu,
+                :old.geo_ref,
+                :old.geo_insee,
+                :old.geom,
+                :old.geo_dv,
+                :old.geo_df,
+                :old.geo_texte,
+                :old.geo_poi_ln,
+                :old.geo_poi_la,
+                :old.geo_poi_ag_orientation,
+                :old.geo_poi_ha,
+                :old.geo_poi_ag_inclinaison,
+                :old.geo_type,
+                username,
+                sysdate,
+                1
+            );
+        END IF;
+        IF DELETING THEN
+            INSERT INTO GEO.TA_POINT_TOPO_F_RECAL_LOG(FID_IDENTIFIANT, CLA_INU, GEO_REF, GEO_INSEE, GEOM, GEO_DV, GEO_DF, GEO_TEXTE, GEO_POI_LN, GEO_POI_LA, GEO_POI_AG_ORIENTATION, GEO_POI_HA, GEO_POI_AG_INCLINAISON, GEO_TYPE, GEO_NMN, GEO_DM, MODIFICATION) 
+            VALUES( :old.objectid,
+                :old.cla_inu,
+                :old.geo_ref,
+                :old.geo_insee,
+                :old.geom,
+                :old.geo_dv,
+                :old.geo_df,
+                :old.geo_texte,
+                :old.geo_poi_ln,
+                :old.geo_poi_la,
+                :old.geo_poi_ag_orientation,
+                :old.geo_poi_ha,
+                :old.geo_poi_ag_inclinaison,
+                :old.geo_type,
+                username,
+                sysdate,
+                0
+            );
+        END IF;
+
+        EXCEPTION
+            WHEN OTHERS THEN
+                mail.sendmail('geotrigger@lillemetropole.fr',username || ' a provoque l''erreur : ' || SQLERRM,'ERREUR TRIGGER - geo/dev.TA_PT_TOPO_F_RECAL_LOG','bjacq@lillemetropole.fr');
+    END;


### PR DESCRIPTION
## Objectif
Créer des objets en base afin de permettre aux Topos de recaler leurs objets. Les tables de recalage doivent être les duplicatas des tables de production avec un filtre sur les objets valides et présents dans un buffer de 20m autours de Chéreng (pour un premier test).
Les tables de versionnement doivent, quant à elles, permettre d'enregistrer toutes édition/suppression des tables de recalage.
Le versionnement sont permis par des triggers.

### Actions à mener
Créer les objets suivants : 
* 4 tables :
- [ ] TA_LIG_TOPO_F_RECAL ;
- [ ] TA_LIG_TOPO_F_RECAL_LOG ;
- [ ] TA_POINT_TOPO_F_RECAL ;
- [ ] TA_POINT_TOPO_F_RECAL_LOG

* Triggers de versionnement des modifications dans les tables de recalage :
- [ ] B_UDX_TA_LIG_TOPO_F_RECAL ;
- [ ] B_UD_X_TA_POINT_TOPO_F_RECAL ;

- [ ] un reviewer a été ajouté
- [ ] le code et les noms d'objets suivent la [syntaxe](https://github.com/meldig/SQL/blob/master/doc/syntaxe.md)
