### PR TITLE
Update gestion_geo_correction_url.sql

### DIFF
--- a/integration/G_GESTIONGEO/gestion_geo_correction_url.sql
+++ b/integration/G_GESTIONGEO/gestion_geo_correction_url.sql
@@ -90,7 +90,7 @@ SET LIEN = REPLACE(LIEN,'/','\');
 
 UPDATE G_DALC.TEMP_GG_FILES_LIST
 SET LIEN = CONCAT('\\volt\infogeo',
-                    SUBSTR(LIEN,INSTR(LIEN,'\Appli_GG'),LENGTH(LIEN))
+                    SUBSTR(LIEN,INSTR(LIEN,'\Donnees'),LENGTH(LIEN))
                     );
 
 


### PR DESCRIPTION
## Objectif
correction ligne 93 car les dossiers GESTION GEO seront déplacé dans le répertoire:
P:\Donnees\Interne\gestiongeo

### Actions à mener
Correction d'une ligne de code car lors du déploiement de la nouvelle version de l'application gestion geo, les dossiers ne seront plus créés dans le répertoire:
- **P:\Appli_GG**
mais dans le répertoire:
- **P:\Donnees\Interne\gestiongeo.** Sans sous répertoire IC, RECOL ou MAJ.

- [X] un reviewer a été ajouté
- [X] le code et les noms d'objets suivent la [syntaxe](https://github.com/meldig/SQL/blob/master/doc/syntaxe.md)
